### PR TITLE
Test custom domain with deploy preview workflow

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -40,7 +40,7 @@ jobs:
           source-dir: ./_site
           preview-branch: gh-pages
           umbrella-dir: pr-preview
-          pages-base-url: wpaccessibility.org
+          pages-base-url: ideagrapes.com
           action: deploy
 
   cleanup-preview:

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -30,7 +30,7 @@ jobs:
           cache-version: 0
 
       - name: Build with Jekyll
-        run: bundle exec jekyll build --baseurl "/pr-preview/pr-${{ github.event.pull_request.number }}"
+        run: bundle exec jekyll build
         env:
           JEKYLL_ENV: production
 
@@ -41,18 +41,6 @@ jobs:
           preview-branch: gh-pages
           umbrella-dir: pr-preview
           action: deploy
-
-      - name: Add CNAME file for custom domain support
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout gh-pages
-          if [ ! -f CNAME ]; then
-            echo "wpaccessibility.org" > CNAME
-            git add CNAME
-            git commit -m "Add CNAME file for custom domain support"
-            git push origin gh-pages
-          fi
 
   cleanup-preview:
     if: github.event.action == 'closed'

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -42,6 +42,19 @@ jobs:
           umbrella-dir: pr-preview
           action: deploy
 
+      - name: Add CNAME file to gh-pages for custom domain
+        run: |
+          git fetch origin gh-pages:gh-pages || git checkout --orphan gh-pages
+          git checkout gh-pages
+          if [ ! -f CNAME ]; then
+            echo "wpaccessibility.org" > CNAME
+            git add CNAME
+            git -c user.name="github-actions[bot]" -c user.email="github-actions[bot]@users.noreply.github.com" commit -m "Add CNAME file for custom domain"
+            git push origin gh-pages
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   cleanup-preview:
     if: github.event.action == 'closed'
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -30,7 +30,7 @@ jobs:
           cache-version: 0
 
       - name: Build with Jekyll
-        run: bundle exec jekyll build
+        run: bundle exec jekyll build --baseurl "/pr-preview/pr-${{ github.event.pull_request.number }}"
         env:
           JEKYLL_ENV: production
 
@@ -40,6 +40,7 @@ jobs:
           source-dir: ./_site
           preview-branch: gh-pages
           umbrella-dir: pr-preview
+          pages-base-url: wpaccessibility.org
           action: deploy
 
   cleanup-preview:

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -42,18 +42,17 @@ jobs:
           umbrella-dir: pr-preview
           action: deploy
 
-      - name: Add CNAME file to gh-pages for custom domain
+      - name: Add CNAME file for custom domain support
         run: |
-          git fetch origin gh-pages:gh-pages || git checkout --orphan gh-pages
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout gh-pages
           if [ ! -f CNAME ]; then
             echo "wpaccessibility.org" > CNAME
             git add CNAME
-            git -c user.name="github-actions[bot]" -c user.email="github-actions[bot]@users.noreply.github.com" commit -m "Add CNAME file for custom domain"
+            git commit -m "Add CNAME file for custom domain support"
             git push origin gh-pages
           fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   cleanup-preview:
     if: github.event.action == 'closed'

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -1,0 +1,54 @@
+name: Deploy PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
+        with:
+          ruby-version: '3.3.6'
+          bundler-cache: true
+          cache-version: 0
+
+      - name: Build with Jekyll
+        run: bundle exec jekyll build --baseurl "/pr-preview/pr-${{ github.event.pull_request.number }}"
+        env:
+          JEKYLL_ENV: production
+
+      - name: Deploy PR Preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./_site
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: deploy
+
+  cleanup-preview:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup PR Preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: remove

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+wpaccessibility.org

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-wpaccessibility.org
+ideagrapes.com

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-wpaccessibility.org

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Did we miss a topic? Did you find an error or have a great idea? Create an issue
 
 We would like to [invite you to contribute](/docs/contribute/) to this Knowledge Base.
 
+## Pull Request Previews
+
+When you create a pull request, a preview of your changes will be automatically deployed and a comment will be added to your PR with a link to the preview site. This allows you and reviewers to see how your changes will look before merging.
+
+Preview URLs follow the format: `https://wpaccessibility.org/pr-preview/pr-{number}/`
+
 ## Local install of the website
 
 WPaccessibility.org is written in [Jekyll](https://jekyllrb.com), a static site generator in Ruby using [markdown](https://www.markdownguide.org/) for content.

--- a/_config.yml
+++ b/_config.yml
@@ -68,9 +68,7 @@ exclude:
   # theme test code
   - fixtures/
 
-# Include CNAME file for GitHub Pages custom domain
-include:
-  - CNAME
+
 
 # Enable or disable the site search
 # Supports true (default) or false

--- a/_config.yml
+++ b/_config.yml
@@ -68,6 +68,10 @@ exclude:
   # theme test code
   - fixtures/
 
+# Include CNAME file for GitHub Pages custom domain
+include:
+  - CNAME
+
 # Enable or disable the site search
 # Supports true (default) or false
 search_enabled: true


### PR DESCRIPTION
This pull request adds automated deployment of pull request previews for the site, making it easier for contributors and reviewers to see changes before merging. It introduces a GitHub Actions workflow for building and deploying previews and updates documentation to explain the new feature.

**PR Preview Deployment**

* Added `.github/workflows/deploy-pr-preview.yml` to automatically build and deploy a preview of pull request changes using Jekyll and the `rossjrw/pr-preview-action` GitHub Action. Previews are deployed for open PRs and cleaned up when PRs are closed.

**Documentation Updates**

* Updated `README.md` to describe the new pull request preview feature, including the preview URL format and how it helps contributors and reviewers.